### PR TITLE
Initial commit for remaining top menu updates

### DIFF
--- a/src/components/static/Navigation.svelte
+++ b/src/components/static/Navigation.svelte
@@ -76,7 +76,7 @@
   >
   <div class="flex w-full justify-center">
 
-    <div class="flex flex-wrap items-center justify-between w-3/4 h-20 px-4">
+    <div class="flex flex-wrap items-center justify-between w-full mx-8 lg:w-3/4 h-20">
       <div class="flex items-center justify-start">
         <a href="/" class="flex mr-4">
           <span
@@ -87,7 +87,7 @@
       </div>
       <div class="flex items-center lg:order-2">
         {#if !isMenuHidden}
-        <div class="mx-4">
+        <div class="hidden lg:block mx-4">
           <RedButton text="GET IN TOUCH"/>
         </div>
         {/if}
@@ -96,7 +96,7 @@
           id="toggleSidebar"
           aria-expanded="true"
           aria-controls="sidebar"
-          class="hidden p-2 mr-3 text-white rounded cursor-pointer lg:inline hover:bg-mcswf-dark-blue hover:text-mcswf-gold hover:text-whit"
+          class="p-2 mr-3 hidden text-white rounded cursor-pointer lg:inline hover:bg-mcswf-dark-blue hover:text-mcswf-gold hover:text-whit"
         >
         {#if isMenuHidden}
         <Icon class="hover:text-mcswf-gold" icon="mdi:menu" />
@@ -108,12 +108,12 @@
           on:click={toggleMenu}
           aria-expanded="true"
           aria-controls="sidebar"
-          class="p-2 mr-2 text-white rounded-lg cursor-pointer lg:hidden hover:bg-mcswf-dark-blue hover:text-mcswf-gold"
+          class="text-white rounded-lg cursor-pointer lg:hidden hover:bg-mcswf-dark-blue hover:text-mcswf-gold"
         >
         {#if isMenuHidden}
         <Icon class="hover:text-mcswf-gold" icon="mdi:menu" />
         {:else}
-        <Icon class="hover:text-mcswf-gold" icon="mdi:close" />
+        <Icon height="20" width="20" class="hover:text-mcswf-gold" icon="mdi:close" />
         {/if}
           <span class="sr-only">Toggle sidebar</span>
         </button>
@@ -122,16 +122,16 @@
   </div>
     {#if !isMenuHidden}
       <!-- STANDARD NAVBAR -->
-      <div class="hidden mx-24 my-4 text-white lg:block xl:block 2xl:block h-96">
-        <div class="flex justify-center">
+      <div class="hidden text-white lg:block xl:block 2xl:block h-96" style="margin-left: 12.5%; margin-right: 12.5%;">
+        <div class="flex">
           {#each dropdownLinks as dropdown}
           <div
-            class="mt-4 transition transform hover:text-mcswf-gold hover:scale-110 px-14"
+            class="mt-4 transition transform hover:text-mcswf-gold hover:scale-110 pr-10"
             on:mouseleave={() => closeDropdown(dropdown.text)}
             on:mouseenter={() => openDropdown(dropdown.text)}
           >
             <a href={dropdown.url}>
-              <h2 class="font-bold">{dropdown.text}</h2>
+              <h2 style="font-size:20px" class="pb-1 font-bold">{dropdown.text}</h2>
               <img
                 class="rounded shadow-lg"
                 src={dropdown.image}
@@ -140,7 +140,7 @@
             </a>
             <div class={`mt-2 ${dropdowns[dropdown.text] ? 'submenu' : 'hidden'}`}>
               {#each dropdown.subLinks as subLinks}
-              <div class="my-1 font-bold text-white hover:text-mcswf-gold hover:underline decoration-2">
+              <div class="my-1 font-bold text-white hover:text-mcswf-gold hover:underline underline-offset-4 decoration-2">
                 <a href={subLinks.url}>{subLinks.text}</a>
               </div>
               {/each}
@@ -173,7 +173,7 @@
             </h1>
             <div class={dropdowns[dropdown.text] ? 'submenu' : 'hidden'}>
               {#each dropdown.subLinks as subLinks}
-              <div class="font-bold text-white hover:text-mcswf-gold hover:underline decoration-2">
+              <div class="py-1 font-bold text-white hover:text-mcswf-gold hover:underline decoration-2">
                 <a class="ms-4" href={subLinks.url}>{subLinks.text}</a>
               </div>
               {/each}

--- a/src/components/static/Navigation.svelte
+++ b/src/components/static/Navigation.svelte
@@ -1,6 +1,6 @@
 <script>
-  import Icon from "@iconify/svelte"
-  import RedButton from "../buttons/WhiteButton.svelte"
+  import Icon from '@iconify/svelte'
+  import RedButton from '../buttons/WhiteButton.svelte'
 
   let isMenuHidden = true
 
@@ -37,6 +37,7 @@
         { url: '/roles/job-listings', text: 'JOB LISTINGS' },
         { url: '/roles/the-progress', text: 'THE PROGRESS' },
       ],
+      titleClasses: 'text-sm lg:text-xl',
     },
     {
       text: 'CONTACT',
@@ -50,7 +51,7 @@
   ]
 
   for (const link in dropdownLinks) {
-    dropdowns[dropdownLinks[link].text] = false 
+    dropdowns[dropdownLinks[link].text] = false
   }
 
   //console.log(dropdownLinks)
@@ -72,87 +73,99 @@
 
 <header class="relative antialiased blue-radial-gradient rounded-b-3xl">
   <nav
-    class="w-full h-full bg-gray-800 border-gray-200 w blue-radial-gradient justify-center" class:rounded-b-3xl={!isMenuHidden}
+    class="w-full h-full bg-gray-800 border-gray-200 w blue-radial-gradient justify-center"
+    class:rounded-b-3xl={!isMenuHidden}
   >
-  <div class="flex w-full justify-center">
-
-    <div class="flex flex-wrap items-center justify-between w-full mx-8 lg:w-3/4 h-20">
-      <div class="flex items-center justify-start">
-        <a href="/" class="flex mr-4">
-          <span
-            class="self-center text-lg font-semibold text-white font-colossalis whitespace-nowrap"
-            >U.S. MARINE CORPS<br />SOFTWARE FACTORY</span
-          >
-        </a>
-      </div>
-      <div class="flex items-center lg:order-2">
-        {#if !isMenuHidden}
-        <div class="hidden lg:block mx-4">
-          <RedButton text="GET IN TOUCH"/>
+    <div class="flex w-full justify-center">
+      <div
+        class="flex flex-wrap items-center justify-between w-full mx-8 lg:w-3/4 h-20"
+      >
+        <div class="flex items-center justify-start">
+          <a href="/" class="flex mr-4">
+            <span
+              class="self-center text-lg font-semibold text-white font-colossalis whitespace-nowrap"
+              >U.S. MARINE CORPS<br />SOFTWARE FACTORY</span
+            >
+          </a>
         </div>
-        {/if}
-        <button
-          on:click={toggleMenu}
-          id="toggleSidebar"
-          aria-expanded="true"
-          aria-controls="sidebar"
-          class="p-2 mr-3 hidden text-white rounded cursor-pointer lg:inline hover:bg-mcswf-dark-blue hover:text-mcswf-gold hover:text-whit"
-        >
-        {#if isMenuHidden}
-        <Icon class="hover:text-mcswf-gold" icon="mdi:menu" />
-        {:else}
-        <Icon class="hover:text-mcswf-gold" icon="mdi:close" />
-        {/if}
-        </button>
-        <button
-          on:click={toggleMenu}
-          aria-expanded="true"
-          aria-controls="sidebar"
-          class="text-white rounded-lg cursor-pointer lg:hidden hover:bg-mcswf-dark-blue hover:text-mcswf-gold"
-        >
-        {#if isMenuHidden}
-        <Icon class="hover:text-mcswf-gold" icon="mdi:menu" />
-        {:else}
-        <Icon class="hover:text-mcswf-gold h-5 w-5" icon="mdi:close" />
-        {/if}
-          <span class="sr-only">Toggle sidebar</span>
-        </button>
+        <div class="flex items-center lg:order-2">
+          {#if !isMenuHidden}
+            <div class="hidden lg:block mx-4">
+              <RedButton text="GET IN TOUCH" />
+            </div>
+          {/if}
+          <button
+            on:click={toggleMenu}
+            id="toggleSidebar"
+            aria-expanded="true"
+            aria-controls="sidebar"
+            class="p-2 mr-3 hidden text-white rounded cursor-pointer lg:inline hover:bg-mcswf-dark-blue hover:text-mcswf-gold hover:text-whit"
+          >
+            {#if isMenuHidden}
+              <Icon class="hover:text-mcswf-gold" icon="mdi:menu" />
+            {:else}
+              <Icon class="hover:text-mcswf-gold" icon="mdi:close" />
+            {/if}
+          </button>
+          <button
+            on:click={toggleMenu}
+            aria-expanded="true"
+            aria-controls="sidebar"
+            class="text-white rounded-lg cursor-pointer lg:hidden hover:bg-mcswf-dark-blue hover:text-mcswf-gold"
+          >
+            {#if isMenuHidden}
+              <Icon class="hover:text-mcswf-gold" icon="mdi:menu" />
+            {:else}
+              <Icon class="hover:text-mcswf-gold h-5 w-5" icon="mdi:close" />
+            {/if}
+            <span class="sr-only">Toggle sidebar</span>
+          </button>
+        </div>
       </div>
     </div>
-  </div>
     {#if !isMenuHidden}
       <!-- STANDARD NAVBAR -->
-      <div class="hidden flex w-full text-white lg:flex h-96 justify-center ">
-        <div class="flex w-3/4 justify-left">
+      <div class="hidden w-full text-white md:flex h-96 justify-center p-4">
+        <div class="grid grid-cols-4 lg:gap-14 gap-10">
           {#each dropdownLinks as dropdown}
-          <div
-            class="mt-4 transition transform hover:text-mcswf-gold hover:scale-110 pr-10"
-            on:mouseleave={() => closeDropdown(dropdown.text)}
-            on:mouseenter={() => openDropdown(dropdown.text)}
-          >
-            <a href={dropdown.url}>
-              <h2 class="text-xl pl-2 pb-1 font-bold">{dropdown.text}</h2>
-              <img
-                class="rounded shadow-lg"
-                src={dropdown.image}
-                alt={dropdown.text}
-              />
-            </a>
-            <div class={`mt-2 ${dropdowns[dropdown.text] ? 'submenu' : 'hidden'}`}>
-              {#each dropdown.subLinks as subLinks}
-              <div class="my-1 font-bold text-white hover:text-mcswf-gold hover:underline underline-offset-4 decoration-2">
-                <a href={subLinks.url}>{subLinks.text}</a>
+            <div
+              role="button"
+              tabindex="0"
+              class="mt-4 transition transform hover:text-mcswf-gold hover:scale-110"
+              on:mouseleave={() => closeDropdown(dropdown.text)}
+              on:mouseenter={() => openDropdown(dropdown.text)}
+            >
+              <a href={dropdown.url}>
+                <h2
+                  class="{dropdown.titleClasses
+                    ? dropdown.titleClasses
+                    : 'text-base lg:text-xl'} pb-1 pl-2 font-bold transition-all"
+                >
+                  {dropdown.text}
+                </h2>
+                <img
+                  class="object-scale-down rounded shadow-lg"
+                  src={dropdown.image}
+                  alt={dropdown.text}
+                />
+              </a>
+              <div
+                class={`mt-2 ${dropdowns[dropdown.text] ? 'submenu' : 'hidden'}`}
+              >
+                {#each dropdown.subLinks as subLinks}
+                  <div
+                    class="my-1 font-bold text-white hover:text-mcswf-gold hover:underline underline-offset-4 decoration-2"
+                  >
+                    <a href={subLinks.url}>{subLinks.text}</a>
+                  </div>
+                {/each}
               </div>
-              {/each}
             </div>
-          </div>
           {/each}
         </div>
       </div>
       <!-- MOBILE NAVBAR -->
-      <div
-        class="grid visible h-screen grid-cols-1 gap-2 lg:hidden xl:hidden 2xl:hidden"
-      >
+      <div class="grid visible h-screen grid-cols-1 gap-2 md:hidden">
         <div class="pt-8 h-1/2">
           <div>
             <h1 class="text-xl font-bold text-center underline text-mcswf-gold">
@@ -160,25 +173,35 @@
             </h1>
           </div>
           {#each dropdownLinks as dropdown}
-          <div class="pt-4 mx-8">
-            <h1 class="flex justify-between font-bold hover:text-mcswf-gold" on:click={() => toggleDropdown(dropdown.text)}>
-              <span class="menu-item"
-                ><a href={dropdown.url}>{dropdown.text}</a></span
+            <div class="pt-4 mx-8">
+              <a
+                class="flex justify-between font-bold hover:text-mcswf-gold"
+                href={dropdown.url}
+                role="button"
+                on:click={() => toggleDropdown(dropdown.text)}
+                on:keydown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    toggleDropdown(dropdown.text)
+                  }
+                }}
               >
-              {#if dropdown.subLinks.length > 0}
-              <span class="text-xl text-right"
-                >{dropdowns[dropdown.text] ? '-' : '+'}</span
-              >
-              {/if}
-            </h1>
-            <div class={dropdowns[dropdown.text] ? 'submenu' : 'hidden'}>
-              {#each dropdown.subLinks as subLinks}
-              <div class="py-1 font-bold text-white hover:text-mcswf-gold hover:underline decoration-2">
-                <a class="ms-4" href={subLinks.url}>{subLinks.text}</a>
+                <span class="menu-item">{dropdown.text}</span>
+                {#if dropdown.subLinks.length > 0}
+                  <span class="text-xl text-right"
+                    >{dropdowns[dropdown.text] ? '-' : '+'}</span
+                  >
+                {/if}
+              </a>
+              <div class={dropdowns[dropdown.text] ? 'submenu' : 'hidden'}>
+                {#each dropdown.subLinks as subLinks}
+                  <div
+                    class="py-1 font-bold text-white hover:text-mcswf-gold hover:underline decoration-2"
+                  >
+                    <a class="ms-4" href={subLinks.url}>{subLinks.text}</a>
+                  </div>
+                {/each}
               </div>
-              {/each}
             </div>
-          </div>
           {/each}
         </div>
       </div>

--- a/src/components/static/Navigation.svelte
+++ b/src/components/static/Navigation.svelte
@@ -122,7 +122,7 @@
   </div>
     {#if !isMenuHidden}
       <!-- STANDARD NAVBAR -->
-      <div class="hidden flex w-full text-white lg:flex xl:flex 2xl:flex h-96 justify-center ">
+      <div class="hidden flex w-full text-white lg:flex h-96 justify-center ">
         <div class="flex w-3/4 justify-left">
           {#each dropdownLinks as dropdown}
           <div
@@ -131,7 +131,7 @@
             on:mouseenter={() => openDropdown(dropdown.text)}
           >
             <a href={dropdown.url}>
-              <h2 class="text-xl pb-1 font-bold">{dropdown.text}</h2>
+              <h2 class="text-xl pl-2 pb-1 font-bold">{dropdown.text}</h2>
               <img
                 class="rounded shadow-lg"
                 src={dropdown.image}

--- a/src/components/static/Navigation.svelte
+++ b/src/components/static/Navigation.svelte
@@ -113,7 +113,7 @@
         {#if isMenuHidden}
         <Icon class="hover:text-mcswf-gold" icon="mdi:menu" />
         {:else}
-        <Icon height="20" width="20" class="hover:text-mcswf-gold" icon="mdi:close" />
+        <Icon class="hover:text-mcswf-gold h-5 w-5" icon="mdi:close" />
         {/if}
           <span class="sr-only">Toggle sidebar</span>
         </button>
@@ -122,8 +122,8 @@
   </div>
     {#if !isMenuHidden}
       <!-- STANDARD NAVBAR -->
-      <div class="hidden text-white lg:block xl:block 2xl:block h-96" style="margin-left: 12.5%; margin-right: 12.5%;">
-        <div class="flex">
+      <div class="hidden flex w-full text-white lg:flex xl:flex 2xl:flex h-96 justify-center ">
+        <div class="flex w-3/4 justify-left">
           {#each dropdownLinks as dropdown}
           <div
             class="mt-4 transition transform hover:text-mcswf-gold hover:scale-110 pr-10"
@@ -131,7 +131,7 @@
             on:mouseenter={() => openDropdown(dropdown.text)}
           >
             <a href={dropdown.url}>
-              <h2 style="font-size:20px" class="pb-1 font-bold">{dropdown.text}</h2>
+              <h2 class="text-xl pb-1 font-bold">{dropdown.text}</h2>
               <img
                 class="rounded shadow-lg"
                 src={dropdown.image}


### PR DESCRIPTION
Remaining work for top menu

 X Bottom Spacing of Menu titles/Copy and images is not there. 
 X Font size is wrong. 20px desktop. 
 X Too much space between each section 37px current is a lot more
 X Images are 200x150 fine with current size, but the images are too spaced out.
 X Product section needs to be aligned with MCSWf logo it is not. Adjust leading of copy title and images to match figma.
 X Also the highlight should be a solid bar not just a line 3px 
 X Bottom of menu needs to be rounded (see figma) 
 X Menu section titles font size is wrong desktop 16px\
 X There is no RED line in the design/menu remove 
 X Mobile sub menu leading/i.e. Spacing between menus need to be more too close together see figma. 
 X Mobile close icon should be larger and aligned to the right .
 X On hover remove black background.