### PR TITLE
Use ButtonCustom from Astro

### DIFF
--- a/src/components/buttons/ButtonCustomFromAstro.svelte
+++ b/src/components/buttons/ButtonCustomFromAstro.svelte
@@ -1,0 +1,15 @@
+<script>
+  import ButtonCustom from '../buttons/ButtonCustom.svelte'
+
+  export let color = 'white' // white, yellow, red
+  export let size = 'md' // xs, sm, md, lg, xl
+  export let link = ''
+  export let linkText = ''
+  export let customClasses = ''
+  export let disabled = false
+  export let handleClick = null
+</script>
+
+<ButtonCustom {color} {size} {customClasses} {link} {disabled} {handleClick}>
+  {linkText}
+</ButtonCustom>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro'
 import Hero from '../components/elements/Hero.svelte'
 import ContentImageFull from '../components/sections/ContentImageFull.svelte'
 import FooterFull from '../components/footer/FooterFull.svelte'
-import ButtonCustom from '../components/buttons/ButtonCustom.svelte'
+import ButtonCustomFromAstro from '../components/buttons/ButtonCustomFromAstro.svelte'
 import MetricCard from '../components/cards/MetricCard.svelte'
 import { getCollection, type CollectionEntry } from 'astro:content'
 import { displaySiteBanner } from '../components/stores.js'
@@ -123,13 +123,13 @@ const metrics = await getCollection('aboutMetrics')
             INTERESTED IN BEING A <br />PART OF THE MCSWF?
           </h2>
           <div class="grid w-full gap-3 mt-8 sm:inline-flex sm:justify-center">
-            <ButtonCustom
+            <ButtonCustomFromAstro
               color="white"
               size="xl"
               customClasses="w-64"
-              link="/#">
-              LEARN MORE
-            </ButtonCustom>
+              link="#"
+              linkText="LEARN MORE"
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
The ButtonCustom Svelte component doesn't seem to be able to get the slot text when it's used directly in an Astro file, and we need a Button in the last section of the About page (can't use ContentImageFull component because Mas put images on both sides of that section). This creates a new Button component that basically is just a pass through to CustomButton. There are probably better solutions, but this is what I came up with...