### PR TITLE
Add breakpoint width to fix overlapping metric cards.

### DIFF
--- a/src/components/cards/MetricCard.svelte
+++ b/src/components/cards/MetricCard.svelte
@@ -4,7 +4,7 @@
   export let metric;
 </script>
   
-<div class="rounded-lg flex h-72 w-56 border-2 p-4 border-white">
+<div class="rounded-lg flex h-72 w-56 lg:w-48 xl:w-56 border-2 p-4 border-white">
   <div class="w-7/8 m-auto align-middle grid gap-4">
     <img class="mx-auto max-h-24" src={icon} alt="Description" />
     <h3 class="text-6xl h-12 text-white font-menobanner">{value}</h3>

--- a/src/components/cards/MetricCard.svelte
+++ b/src/components/cards/MetricCard.svelte
@@ -3,11 +3,11 @@
   export let value;
   export let metric;
 </script>
-  
+
 <div class="rounded-lg flex h-72 w-56 lg:w-48 xl:w-56 border-2 p-4 border-white">
   <div class="w-7/8 m-auto align-middle grid gap-4">
     <img class="mx-auto max-h-24" src={icon} alt="Description" />
     <h3 class="text-6xl h-12 text-white font-menobanner">{value}</h3>
-    <p class="content-center font-semibold text-large text-mcswf-gold">{metric}</p>
+    <p class="content-center font-semibold text-lg text-mcswf-gold">{metric}</p>
   </div>
 </div>


### PR DESCRIPTION
Corrects issue where metric cards overlap when between the large and extra large breakpoints.